### PR TITLE
Add missing migraiton for later versions of Django CMS

### DIFF
--- a/djangocms_twitter/migrations/0002_update_related_name.py
+++ b/djangocms_twitter/migrations/0002_update_related_name.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_twitter', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='twitterrecententries',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, related_name='djangocms_twitter_twitterrecententries', serialize=False, to='cms.CMSPlugin'),
+        ),
+        migrations.AlterField(
+            model_name='twittersearch',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, related_name='djangocms_twitter_twittersearch', serialize=False, to='cms.CMSPlugin'),
+        ),
+    ]


### PR DESCRIPTION
For later versions of Django & Django CMS there's a missing migration. When you try to run `./manage.py migrate` Django gives the below message:

```
Your models have changes that are not yet reflected in a migration, and so won't be applied.
Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
```
This looks like it's related to [this issue](https://github.com/divio/django-cms/issues/5550). 

This pull request adds that missing migration.